### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hyperbrowser MCP Server
 [![smithery badge](https://smithery.ai/badge/@hyperbrowserai/mcp)](https://smithery.ai/server/@hyperbrowserai/mcp)
 
+<a href="https://glama.ai/mcp/servers/@hyperbrowserai/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hyperbrowserai/mcp/badge" alt="Hyperbrowser MCP server" />
+</a>
+
 ![Frame 5](https://github.com/user-attachments/assets/3309a367-e94b-418a-a047-1bf1ad549c0a)
 
 This is Hyperbrowser's Model Context Protocol (MCP) Server. It provides various tools to scrape, extract structured data, and crawl webpages. It also provides easy access to general purpose browser agents like OpenAI's CUA, Anthropic's Claude Computer Use, and Browser Use.


### PR DESCRIPTION
This PR adds a badge for the [Hyperbrowser](https://glama.ai/mcp/servers/@hyperbrowserai/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hyperbrowserai/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hyperbrowserai/mcp/badge" alt="Hyperbrowser MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.