### PR TITLE
Fix Claude Desktop MCP config args

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This is an example config for the Hyperbrowser MCP server for the Claude Desktop
   "mcpServers": {
     "hyperbrowser": {
       "command": "npx",
-      "args": ["--yes", "hyperbrowser-mcp"],
+      "args": ["hyperbrowser-mcp"],
       "env": {
         "HYPERBROWSER_API_KEY": "your-api-key"
       }


### PR DESCRIPTION
## What\n- Update the Claude Desktop MCP example to use the package arg directly, matching the config requested in issue #9.\n\n## Why\nThe current README shows ; issue #9 reports that this config is incorrect for Claude Desktop and should be .\n\n## Verification\n- git diff --check\n- npm run build