### PR TITLE
Fix broken Smithery badge (returns HTTP 500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hyperbrowser MCP Server
-[![smithery badge](https://smithery.ai/badge/@hyperbrowserai/mcp)](https://smithery.ai/server/@hyperbrowserai/mcp)
+[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.hyperbrowserai/mcp.svg)](https://skillselion.com/mcp/tool/io.github.hyperbrowserai/mcp)
 
 ![Frame 5](https://github.com/user-attachments/assets/3309a367-e94b-418a-a047-1bf1ad549c0a)
 


### PR DESCRIPTION
The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/@hyperbrowserai/mcp   ->  500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem.

**What this PR does:** removes that one dead badge line, and offers ours in its place.

```markdown
[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.hyperbrowserai/mcp.svg)](https://skillselion.com/mcp/tool/io.github.hyperbrowserai/mcp)
```

We'd be happy to have ours sit there instead — Skillselion is an independent directory of agent skills and MCP servers, and this project is already listed at https://skillselion.com/mcp/tool/io.github.hyperbrowserai/mcp whether or not you take the badge.

**Entirely your call, and no hard feelings either way:**
- Happy for the badge to stay → merge as is.
- Prefer the dead badge just gone → say so and I'll amend this to a removal-only change.
- Prefer nothing touched → close it, no reply needed.

Only the dead Smithery image was changed. Any other badges in your README were left untouched.
